### PR TITLE
feat: BTF-23 Download audit log

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,10 +1,39 @@
+<template>
+  
+  <h1>Welcome {{ _kc.tokenParsed?.display_name }}, roles you have are {{ _kc.tokenParsed?.client_roles }}</h1>
+  
+  <button @click="logout">logout</button>
+  <button @click="download">download</button>
+
+</template>
+
 <script setup lang="ts">
 import { logout, _kc } from '../services/keycloak'
 
-</script>
+const download = () => {
+  // Extract and format the relevant data
+  const auditDetails = {
+      idir: _kc.tokenParsed?.idir_username,
+      login: _kc.tokenParsed?.iat ? new Date(_kc.tokenParsed?.iat * 1000).toISOString() : new Date().toISOString(),
+      created: new Date().toISOString()
+    }
 
-<template>
+  // Create text content from the object
+  const textContent = `
+    IDIR: ${auditDetails.idir}
+    Logged in: ${auditDetails.login}
+    File created: ${auditDetails.created}
+  `;
+
+  // Create a text file
+  const textBlob = new Blob([textContent], { type: 'text/plain' });
+  const url = URL.createObjectURL(textBlob);
   
-  <h1>Welcome {{ _kc.tokenParsed?.display_name }}, roles you have are {{ _kc.tokenParsed?.client_roles }}</h1><button @click="logout">logout</button>
-
-</template>
+  // Create an anchor element to trigger the download
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'user-info.txt';
+  link.click();
+  URL.revokeObjectURL(url); // Clean up the URL object  
+};
+</script>


### PR DESCRIPTION
https://finrms.atlassian.net/browse/BTF-23

Add's a button to download the audit details txt to the home page.

Getting the audit details from keycloak is only 3 lines of code, I don't think that needs it's own service. The details are only changed when the page is updated, so a pinia store isn't required. Maybe when the other services are created it will become more clear where the best location for this is.