### PR TITLE
feat: support drag-ang-drop on upload files page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@bcgov/bc-sans": "^2.1.0",
         "@braintree/sanitize-url": "^7.1.0",
         "@mdi/font": "^7.4.47",
-        "dropzone": "^6.0.0-beta.2",
         "fin-tbs-btf-frontend": "file:",
         "keycloak-js": "^25.0.6",
         "pdfjs-dist": "^4.7.76",
@@ -695,11 +694,6 @@
         "win32"
       ]
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
-      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1256,15 +1250,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dropzone": {
-      "version": "6.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
-      "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.2.13",
-        "just-extend": "^5.0.0"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1523,11 +1508,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
       "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
-    },
-    "node_modules/just-extend": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
-      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
     },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
@@ -2970,11 +2950,6 @@
       "dev": true,
       "optional": true
     },
-    "@swc/helpers": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
-      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
-    },
     "@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -3414,15 +3389,6 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "optional": true
     },
-    "dropzone": {
-      "version": "6.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
-      "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
-      "requires": {
-        "@swc/helpers": "^0.2.13",
-        "just-extend": "^5.0.0"
-      }
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3478,7 +3444,6 @@
         "@mdi/font": "^7.4.47",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-vue": "^5.1.4",
-        "dropzone": "^6.0.0-beta.2",
         "fin-tbs-btf-frontend": "file:",
         "keycloak-js": "^25.0.6",
         "pdfjs-dist": "^4.7.76",
@@ -3835,11 +3800,6 @@
           "integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
           "dev": true,
           "optional": true
-        },
-        "@swc/helpers": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
-          "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
         },
         "@types/estree": {
           "version": "1.0.5",
@@ -4280,15 +4240,6 @@
           "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
           "optional": true
         },
-        "dropzone": {
-          "version": "6.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
-          "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
-          "requires": {
-            "@swc/helpers": "^0.2.13",
-            "just-extend": "^5.0.0"
-          }
-        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4481,11 +4432,6 @@
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
           "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
-        },
-        "just-extend": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
-          "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
         },
         "jwt-decode": {
           "version": "4.0.0",
@@ -5276,11 +5222,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
       "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
-    },
-    "just-extend": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
-      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
     },
     "jwt-decode": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@bcgov/bc-sans": "^2.1.0",
     "@braintree/sanitize-url": "^7.1.0",
     "@mdi/font": "^7.4.47",
-    "dropzone": "^6.0.0-beta.2",
     "fin-tbs-btf-frontend": "file:",
     "keycloak-js": "^25.0.6",
     "pdfjs-dist": "^4.7.76",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,31 +1,30 @@
 <template>
-  <v-app >
+  <v-app>
     <MsieBanner v-if="isIE" />
     <Header />
     <SnackBar />
     <v-main fluid class="mx-4 my-4">
-      <RouterView />
+      <v-container class="h-100">
+        <RouterView />
+      </v-container>
     </v-main>
   </v-app>
-
-
 </template>
 
 <script setup lang="ts">
-import { RouterView } from 'vue-router';
-import { computed } from 'vue';
-import Header from './components/Header.vue';
-import MsieBanner from './components/MsieBanner.vue';
-import SnackBar from './components/SnackBar.vue';
+import { RouterView } from "vue-router";
+import { computed } from "vue";
+import Header from "./components/Header.vue";
+import MsieBanner from "./components/MsieBanner.vue";
+import SnackBar from "./components/SnackBar.vue";
 
 const isIE = computed(() => {
-  return /Trident\/|MSIE/.test(window.navigator.userAgent); 
-})
-
+  return /Trident\/|MSIE/.test(window.navigator.userAgent);
+});
 </script>
 
 <style>
-@import '@bcgov/bc-sans/css/BCSans.css';
+@import "@bcgov/bc-sans/css/BCSans.css";
 
 #app {
   max-width: 100% !important;
@@ -53,7 +52,7 @@ a:hover {
 }
 
 .v-application {
-  font-family: 'BCSans', 'Noto Sans', Verdana, Arial, sans-serif !important;
+  font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif !important;
 }
 
 .v-card--flat {
@@ -76,6 +75,11 @@ h1 {
   text-transform: none !important;
 }
 
+.v-btn.btn-icon {
+  min-width: 0px !important;
+  padding: 4px !important;
+}
+
 .v-btn.btn-primary {
   background-color: #053662 !important;
   color: #ffffff !important;
@@ -94,6 +98,11 @@ h1 {
 
 .v-btn.btn-secondary:hover {
   background-color: #edebe9 !important;
+}
+.v-btn.btn-secondary:disabled {
+  background-color: #edebe9 !important;
+  color: #aaaaaa !important;
+  border: none !important;
 }
 
 .v-alert .v-icon {

--- a/src/components/UploadPage.vue
+++ b/src/components/UploadPage.vue
@@ -1,47 +1,76 @@
 <template>
   <v-row dense class="h-50">
     <v-col class="d-inline-block h-100">
-      <h3>Files</h3>
-      <v-card class="w-100 h-100">
-        <v-card-text>
-          <v-list class="w-100">
-            <UploadedFileItem
-              v-for="uploadedFile in uploadedFiles"
-              :key="uploadedFile.uploadedFileId"
-              :uploadedFile="uploadedFile"
+      <h3>
+        Files
+        <span v-if="uploadedFiles.length">({{ uploadedFiles.length }})</span>
+      </h3>
+      <div id="dropzone" class="w-100 h-100">
+        <v-card class="w-100 h-100 bg-grey-lighten-4 overflow-y-auto">
+          <v-card-text class="w-100 h-100">
+            <div
+              class="w-100 h-100 d-flex flex-column justify-center align-center"
+              v-if="!uploadedFiles.length"
             >
-            </UploadedFileItem>
-          </v-list>
-        </v-card-text>
-      </v-card>
-      <div class="d-flex justify-space-between mt-2">
-        <v-btn
-          class="btn-primary"
-          for="fileChooser"
-          @click="$refs.fileChooser?.click()"
-          >Upload a file</v-btn
-        >
-        <v-btn class="btn-secondary ms-2" @click="reset()">Clear</v-btn>
-        <v-file-input
-          id="fileChooser"
-          ref="fileChooser"
-          multiple
-          label="File input"
-          :hide-input="true"
-          :hide-detail="true"
-          prepend-icon="none"
-          accept="application/pdf"
-          @change="onFilesSelected"
-        />
-        <v-btn
-          class="btn-primary"
-          @click="saveExcel"
-          :disabled="uploadedFiles.length == 0 || hasValidationErrors"
-          >Download excel</v-btn
-        >
+              <div id="drop-instructions" class="d-flex align-center">
+                <v-icon
+                  icon="mdi-file-pdf-box"
+                  color="grey-darken-2"
+                  size="x-large"
+                ></v-icon>
+                <h3 class="text-grey-darken-3">Drop PDF files here</h3>
+              </div>
+              <div class="text-grey mt-4">
+                .. or use the <i>Upload PDF</i> button below
+              </div>
+            </div>
+            <v-list
+              class="w-100"
+              bg-color="#00000000"
+              v-if="uploadedFiles?.length"
+            >
+              <UploadedFileItem
+                v-for="uploadedFile in uploadedFiles"
+                :key="uploadedFile.uploadedFileId"
+                :uploadedFile="uploadedFile"
+              >
+              </UploadedFileItem>
+            </v-list>
+          </v-card-text>
+        </v-card>
+        <div class="d-flex justify-space-between mt-2">
+          <v-btn
+            class="btn-primary"
+            for="fileChooser"
+            @click="$refs.fileChooser?.click()"
+            >Upload PDF</v-btn
+          >
+          <v-btn
+            class="btn-secondary ms-2"
+            @click="reset()"
+            :disabled="!uploadedFiles.length"
+            >Clear</v-btn
+          >
+          <v-file-input
+            id="fileChooser"
+            ref="fileChooser"
+            multiple
+            label="File input"
+            :hide-input="true"
+            :hide-detail="true"
+            prepend-icon="none"
+            accept="application/pdf"
+            @change="onFilesSelected"
+          />
+          <v-btn
+            class="btn-primary"
+            @click="saveExcel"
+            :disabled="uploadedFiles.length == 0 || hasValidationErrors"
+            >Download Excel</v-btn
+          >
+        </div>
       </div>
     </v-col>
-    <v-col> </v-col>
   </v-row>
 </template>
 
@@ -50,7 +79,7 @@ import UploadedFileItem from "./UploadedFileItem.vue";
 import { useAuthStore } from "../stores/auth-store";
 import { useUploadedFilesStore } from "../stores/uploaded-files-store";
 import { storeToRefs } from "pinia";
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 import excelService from "../services/excel-service";
 import { excelColumnDefaults, excelColumnOrder } from "../constants";
 
@@ -61,25 +90,61 @@ const { uploadedFiles } = storeToRefs(uploadedFilesStore);
 const { user } = storeToRefs(authStore);
 const fileChooser = ref<any>(null);
 
+onMounted(() => {
+  initFileDropzone();
+});
+
+/* Initializes drag and drop related event handling for an area that 
+will receive dropped files from the user's operating system */
+const initFileDropzone = () => {
+  const dropArea = document.getElementById("dropzone");
+
+  /* Disable browser default behavior for files dropped into the 'dropzone'
+  element. (The default handling is to try to open the file and display it 
+  in the browser.) */
+  const preventDefaultEventHandling = (e: any) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const onDrop = (e: any) => {
+    preventDefaultEventHandling(e);
+    if (e?.dataTransfer.files) {
+      ingestFiles(e?.dataTransfer.files);
+    }
+  };
+
+  dropArea?.addEventListener("dragover", preventDefaultEventHandling);
+  dropArea?.addEventListener("dragenter", preventDefaultEventHandling);
+  dropArea?.addEventListener("dragleave", preventDefaultEventHandling);
+  dropArea?.addEventListener("drop", onDrop);
+};
+
+/* event handler for files uploaded via the "Upload File(s)" button*/
+const onFilesSelected = async (event: Event) => {
+  const files: FileList | null = (event.target as HTMLInputElement).files;
+  ingestFiles(files);
+
+  //clear all previously uploaded files from the v-file-input
+  fileChooser.value?.reset();
+};
+
+const ingestFiles = (files: FileList | null) => {
+  if (files) {
+    uploadedFilesStore.addFileList(files);
+  }
+};
+
+/* Returns true if any one or more files in the uploadedFilesStore
+has a validation error. Returns false otherwise. */
 const hasValidationErrors = computed<boolean>(() => {
   return (
     uploadedFiles.value.filter((f) => f.validationErrors?.length).length > 0
   );
 });
 
-function reset() {
+const reset = () => {
   uploadedFilesStore.reset();
-}
-
-const onFilesSelected = async (event: Event) => {
-  //start the parsing and validation process on the selected
-  //files
-  const files = (event.target as HTMLInputElement).files;
-  if (files) {
-    uploadedFilesStore.addFileList(files);
-  }
-  //clear all previously uploaded files
-  fileChooser.value?.reset();
 };
 
 /** Event handler to save the extracted data to Excel */

--- a/src/components/UploadedFileItem.vue
+++ b/src/components/UploadedFileItem.vue
@@ -22,10 +22,17 @@
     <template v-slot:append>
       <div class="ms-2">
         <v-btn
-          icon="mdi-delete"
-          size="x-small"
+          variant="plain"
+          class="btn-icon"
           @click="uploadedFilesStore.removeUploadedFile(uploadedFile)"
-        ></v-btn>
+        >
+          <v-icon
+            icon="mdi-close-thick"
+            class="px-0"
+            style="min-width: 0px"
+            size="large"
+          ></v-icon>
+        </v-btn>
       </div>
     </template>
   </v-list-item>
@@ -48,3 +55,9 @@ defineProps<{
   uploadedFile: UploadedFile;
 }>();
 </script>
+
+<style>
+.v-list-item {
+  min-height: 0px !important;
+}
+</style>

--- a/src/stores/uploaded-files-store.ts
+++ b/src/stores/uploaded-files-store.ts
@@ -15,6 +15,10 @@ export const useUploadedFilesStore = defineStore("uploadedFiles", () => {
   const uploadedFiles = ref<UploadedFile[]>([]);
 
   const addFile = async (file: File): Promise<void> => {
+    if (fileExists(file)) {
+      //ignore duplicate files
+      return;
+    }
     const uploadedFile: UploadedFile = {
       uploadedFileId: uuidv4(),
       file: file,
@@ -48,6 +52,17 @@ export const useUploadedFilesStore = defineStore("uploadedFiles", () => {
   const removeUploadedFile = (uploadedFile: UploadedFile): void => {
     uploadedFiles.value = uploadedFiles.value.filter(
       (uf: UploadedFile) => uf?.uploadedFileId != uploadedFile?.uploadedFileId,
+    );
+  };
+
+  const fileExists = (file: File): boolean => {
+    return (
+      uploadedFiles.value.filter(
+        (u) =>
+          u.file.lastModified == file.lastModified &&
+          u.file.size == file.size &&
+          u.file.name == file.name,
+      ).length > 0
     );
   };
 


### PR DESCRIPTION
- Added support for drag-ang-drop on upload files page (No external library was needed.  It turns out this is easy with plain javascript.  Also, the dropzone.js library that we considered turned out to be not suitable... it insists on trying to upload files to a backend somewhere.)
- Cleaned up the user interface