### PR TITLE
test: fix E2E login timeout

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -13,9 +13,10 @@ setup("authenticate", async ({ page }) => {
 
   const loginPage = new LoginPage(page);
   await loginPage.visit();
-  await loginPage.expectLoginPage();
-  await loginPage.login();
-  await loginPage.expectLoggedIn();
+  if (!(await loginPage.isLoggedIn())) {
+    await loginPage.expectLoginPage();
+    await loginPage.login();
+  }
 
   await page.context().storageState({ path: authFile });
 });

--- a/e2e/pages/basePage.ts
+++ b/e2e/pages/basePage.ts
@@ -1,5 +1,6 @@
 import { Locator, Page, expect } from "@playwright/test";
 import { PagePaths } from "../utils/paths";
+import { LoginPage } from "./loginPage";
 
 export class BasePage {
   logoutButton: Locator;
@@ -21,6 +22,11 @@ export class BasePage {
     await this.page
       .locator(`[data-test-id="${process.env.E2E_AUTO_TEST_EMAIL}"]`)
       .click();
+    new LoginPage(this.page).waitFor(); // have to wait for the logout to complete or it is cancelled.
+  }
+
+  async isLoggedIn() {
+    return this.logoutButton.isVisible();
   }
 
   //////////

--- a/e2e/pages/basePage.ts
+++ b/e2e/pages/basePage.ts
@@ -1,13 +1,16 @@
 import { Locator, Page, expect } from "@playwright/test";
 import { PagePaths } from "../utils/paths";
-import { LoginPage } from "./loginPage";
 
 export class BasePage {
   logoutButton: Locator;
+  loginButton: Locator;
   userName: Locator;
   constructor(public readonly page: Page) {
     this.logoutButton = this.page.getByRole("button", {
       name: "Logout",
+    });
+    this.loginButton = this.page.getByRole("button", {
+      name: "Login with IDIR MFA",
     });
     this.userName = this.page.getByTestId("account-info");
   }
@@ -22,7 +25,7 @@ export class BasePage {
     await this.page
       .locator(`[data-test-id="${process.env.E2E_AUTO_TEST_EMAIL}"]`)
       .click();
-    new LoginPage(this.page).waitFor(); // have to wait for the logout to complete or it is cancelled.
+    this.loginButton.waitFor(); // have to wait for the logout to complete or it is cancelled.
   }
 
   async isLoggedIn() {

--- a/e2e/pages/loginPage.ts
+++ b/e2e/pages/loginPage.ts
@@ -12,6 +12,11 @@ export class LoginPage extends BasePage {
     });
   }
 
+  /** wait for the login page to be visible */
+  async waitFor() {
+    await this.loginButton.waitFor();
+  }
+
   async login() {
     await this.loginButton.click();
     await this.page.getByLabel("Enter your email, phone, or").click();

--- a/e2e/pages/loginPage.ts
+++ b/e2e/pages/loginPage.ts
@@ -3,15 +3,6 @@ import { BasePage } from "./basePage";
 import { expect, Locator, Page } from "@playwright/test";
 
 export class LoginPage extends BasePage {
-  loginButton: Locator;
-
-  constructor(page: Page) {
-    super(page);
-    this.loginButton = this.page.getByRole("button", {
-      name: "Login with IDIR MFA",
-    });
-  }
-
   /** wait for the login page to be visible */
   async waitFor() {
     await this.loginButton.waitFor();


### PR DESCRIPTION
In the Pull Request history, you can see that most merge-to-main actions have failed during the E2E tests, specifically verification of login success.

1. Moved verifying that the user is logged in to be outsite of the playwright authentication routine. Since playwright logs are limited during authentication, this should help identify what specifically is going wrong at this step.

2. E2E automatic retry is also failing. Now, during playwright authentication, if the user is already logged in, then it will accept those credentials rather than trying to do the login steps again.