### PR TITLE
ci: remove unneccessary actions when PR is closed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write
 jobs:
   unit-tests:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,7 @@ jobs:
   test-e2e-admin:
     name: E2E-Admin
     needs: [build-deploy-pr]
+    if: github.event.action != 'closed'
     uses: ./.github/workflows/.e2e.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Finally found what the error is when merging-to-main. The PR workflow is excecuted when a PR closes in order to delete the pr-preview link. However, the PR workflow also runs unit tests and E2E tests. The E2E tests are failing at this point because the pr-preview site has been removed.

- prevent E2E tests from running when PR is being closed.
- prevent unit tests from running when PR is being closed.